### PR TITLE
fix: do not require plugin's id to be `oidc`, chec the `plugin` attribute

### DIFF
--- a/packages/volto-authomatic/src/components/Login/Login.tsx
+++ b/packages/volto-authomatic/src/components/Login/Login.tsx
@@ -95,12 +95,12 @@ const Login: React.FC = () => {
     if (
       providers !== undefined &&
       providers.length === 1 &&
-      providers[0].id === 'oidc' &&
+      providers[0].plugin === 'oidc' &&
       !displayPlone
     ) {
       setPlugin(providers[0].plugin);
       setStartedOIDC(true);
-      dispatch(oidcRedirect('oidc'));
+      dispatch(oidcRedirect(providers[0].id));
     }
   }, [displayPlone, providers, dispatch]);
 


### PR DESCRIPTION
If for some reason you add 2 oidc plugins, then remove the one named `oidc` suddenly the automatic-login feature does not work.