### PR TITLE
[2.x]: Fallback login redirect

### DIFF
--- a/src/components/FallbackLogin.jsx
+++ b/src/components/FallbackLogin.jsx
@@ -1,0 +1,16 @@
+import { Login } from '@plone/volto/components';
+import { useEffect } from 'react';
+import { useHistory } from 'react-router-dom';
+
+export default function FallbackLogin(props) {
+  const history = useHistory();
+  // Login component doesn't support passing in a return_url so let's set it
+  //   via the querystring so the component can read it.
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    url.searchParams.set('return_url', '/');
+    history.replace(`${history.location.pathname}?${url.searchParams.toString()}`);
+  }, [history]);
+
+  return <Login {...props} />;
+}

--- a/src/components/FallbackLogin.jsx
+++ b/src/components/FallbackLogin.jsx
@@ -7,8 +7,9 @@ export default function FallbackLogin(props) {
   // Login component doesn't support passing in a return_url so let's set it
   //   via the querystring so the component can read it.
   useEffect(() => {
+    const pathname = history.location.pathname.replace(/\/fallback_login\/?$/, '') || '/';
     const url = new URL(window.location.href);
-    url.searchParams.set('return_url', '/');
+    url.searchParams.set('return_url', pathname);
     history.replace(`${history.location.pathname}?${url.searchParams.toString()}`);
   }, [history]);
 

--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -63,6 +63,7 @@ function Login({ intl }) {
     const next_url = loginOIDCValues.next_url;
     if (next_url && startedOIDC) {
       setStartedOIDC(false);
+      setCookie('return_url', getReturnUrl(location), { path: '/' });
       // Give time to save state to localstorage
       setTimeout(function () {
         window.location.href = next_url;

--- a/src/components/LoginOIDC/LoginOIDC.jsx
+++ b/src/components/LoginOIDC/LoginOIDC.jsx
@@ -10,6 +10,7 @@ import { Toast } from '@plone/volto/components';
 import { defineMessages, injectIntl } from 'react-intl';
 import { useParams, useLocation, useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
+import { useCookies } from 'react-cookie';
 
 const messages = defineMessages({
   oAuthLoginFailed: {
@@ -41,6 +42,8 @@ function LoginOIDC({ intl }) {
   const isLoading = userSession.login.loading;
   const error = userSession.login.error;
   const token = userSession.token;
+  const [cookies, , removeCookie] = useCookies();
+  const return_url = cookies.return_url || '/';
 
   useEffect(() => {
     dispatch(oidcLogin(provider, query, session));
@@ -48,7 +51,8 @@ function LoginOIDC({ intl }) {
 
   useEffect(() => {
     if (token) {
-      history.push('/');
+      window.setTimeout(() => removeCookie('return_url', { path: '/' }), 500);
+      history.push(return_url);
       if (toast.isActive('loginFailed')) {
         toast.dismiss('loginFailed');
       }

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ const applyConfig = (config) => {
   ];
   config.addonRoutes.push(
     { path: '/fallback_login', component: FallbackLogin },
+    { path: '/**/fallback_login', component: FallbackLogin },
     { path: '/login', component: Login },
     { path: '/**/login', component: Login },
     { path: '/logout', component: Logout },

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
+import FallbackLogin from './components/FallbackLogin';
 import Login from './components/Login/Login';
 import LoginAuthomatic from './components/LoginAuthomatic/LoginAuthomatic';
 import LoginOIDC from './components/LoginOIDC/LoginOIDC';
 import Logout from './components/Logout/Logout';
 import { authomaticRedirect, authOptions, oidcLogout, oidcRedirect } from './reducers';
-import { Login as VoltoLogin } from '@plone/volto/components';
 
 const applyConfig = (config) => {
   config.addonReducers = {
@@ -21,7 +21,7 @@ const applyConfig = (config) => {
     '/fallback_login',
   ];
   config.addonRoutes.push(
-    { path: '/fallback_login', component: VoltoLogin },
+    { path: '/fallback_login', component: FallbackLogin },
     { path: '/login', component: Login },
     { path: '/**/login', component: Login },
     { path: '/logout', component: Logout },

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,12 @@ const applyConfig = (config) => {
     oidcRedirect,
   };
   config.settings.persistentReducers = [...config.settings.persistentReducers, 'authomaticRedirect', 'oidcLogout', 'oidcRedirect'];
-  config.settings.nonContentRoutes = [...config.settings.nonContentRoutes, /^\/login-authomatic\/.*$/, /^\/login-oidc\/.*$/];
+  config.settings.nonContentRoutes = [
+    ...config.settings.nonContentRoutes,
+    /^\/login-authomatic\/.*$/,
+    /^\/login-oidc\/.*$/,
+    '/fallback_login',
+  ];
   config.addonRoutes.push(
     { path: '/fallback_login', component: VoltoLogin },
     { path: '/login', component: Login },

--- a/src/index.js
+++ b/src/index.js
@@ -14,12 +14,7 @@ const applyConfig = (config) => {
     oidcRedirect,
   };
   config.settings.persistentReducers = [...config.settings.persistentReducers, 'authomaticRedirect', 'oidcLogout', 'oidcRedirect'];
-  config.settings.nonContentRoutes = [
-    ...config.settings.nonContentRoutes,
-    /^\/login-authomatic\/.*$/,
-    /^\/login-oidc\/.*$/,
-    '/fallback_login',
-  ];
+  config.settings.nonContentRoutes = [...config.settings.nonContentRoutes, /^\/login-authomatic\/.*$/, /^\/login-oidc\/.*$/, '/fallback_login'];
   config.addonRoutes.push(
     { path: '/fallback_login', component: FallbackLogin },
     { path: '/**/fallback_login', component: FallbackLogin },


### PR DESCRIPTION
This PR fixes the following issues with the `fallback_login` page:

- The page is unstyled. Now the page has the same CSS applied to it as the login page by marking it as a non-content route
- Adds some basic support for returning to the path we came from (the same as if you appended `/login` to a URL). Note that this works by inserting a querystring client-side, so you can get into a case where this won't trigger if the JS fails or the user is too quick to login

PR against the 2.x branch for Volto 16 support, I'll open a PR against the main branch with the 3.0 refactor _soon_