### PR TITLE
[2.x]: Return URL for OIDC

### DIFF
--- a/src/components/Login/Login.jsx
+++ b/src/components/Login/Login.jsx
@@ -63,6 +63,7 @@ function Login({ intl }) {
     const next_url = loginOIDCValues.next_url;
     if (next_url && startedOIDC) {
       setStartedOIDC(false);
+      setCookie('return_url', getReturnUrl(location), { path: '/' });
       // Give time to save state to localstorage
       setTimeout(function () {
         window.location.href = next_url;

--- a/src/components/LoginOIDC/LoginOIDC.jsx
+++ b/src/components/LoginOIDC/LoginOIDC.jsx
@@ -10,6 +10,7 @@ import { Toast } from '@plone/volto/components';
 import { defineMessages, injectIntl } from 'react-intl';
 import { useParams, useLocation, useHistory } from 'react-router-dom';
 import { useSelector, useDispatch } from 'react-redux';
+import { useCookies } from 'react-cookie';
 
 const messages = defineMessages({
   oAuthLoginFailed: {
@@ -41,6 +42,8 @@ function LoginOIDC({ intl }) {
   const isLoading = userSession.login.loading;
   const error = userSession.login.error;
   const token = userSession.token;
+  const [cookies, , removeCookie] = useCookies();
+  const return_url = cookies.return_url || '/';
 
   useEffect(() => {
     dispatch(oidcLogin(provider, query, session));
@@ -48,7 +51,8 @@ function LoginOIDC({ intl }) {
 
   useEffect(() => {
     if (token) {
-      history.push('/');
+      window.setTimeout(() => removeCookie('return_url', { path: '/' }), 500);
+      history.push(return_url);
       if (toast.isActive('loginFailed')) {
         toast.dismiss('loginFailed');
       }


### PR DESCRIPTION
The Authomatic side of this addon has support for returning the user to the URL they started the login from by setting a cookie before we begin the login process. This PR adds the same cookie to the OIDC workflow. The cookie is retained after logging in with the OIDC server and being redirected back to Volto, where the cookie is removed and the user returned the login path upon login

PR against the 2.x branch for Volto 16 support, I'll open a PR against the main branch with the 3.0 refactor _soon_