### PR TITLE
import settings config file to index folder.

### DIFF
--- a/packages/volto-authomatic/news/+settings.bugfix
+++ b/packages/volto-authomatic/news/+settings.bugfix
@@ -1,1 +1,1 @@
-import settings config file to index folder. @iFlameing
+import settings config file to index file. @iFlameing

--- a/packages/volto-authomatic/news/+settings.bugfix
+++ b/packages/volto-authomatic/news/+settings.bugfix
@@ -1,0 +1,1 @@
+import settings config file to index folder. @iFlameing

--- a/packages/volto-authomatic/src/config/settings.ts
+++ b/packages/volto-authomatic/src/config/settings.ts
@@ -3,6 +3,7 @@ import type { ConfigType } from '@plone/registry';
 declare module '@plone/types' {
   export interface SettingsConfig {
     showPloneLogin: boolean;
+    displayLogout: boolean;
   }
 }
 

--- a/packages/volto-authomatic/src/index.ts
+++ b/packages/volto-authomatic/src/index.ts
@@ -2,11 +2,13 @@ import type { ConfigType } from '@plone/registry';
 
 import installReducers from './config/reducers';
 import installRoutes from './config/routes';
+import installSettings from './config/settings';
 import './styles.css';
 
 export function applyConfig(config: ConfigType) {
   installReducers(config);
   installRoutes(config);
+  installSettings(config);
   return config;
 }
 


### PR DESCRIPTION
@ericof seems that from start we don't import settings folder to index.ts. Why it is working earlier for your settings because it is false and when you access it returned false. I developed the feature in intranet. I set the variable in intranet and for me it works from there. But when I tried in core it start failing so I found out this issue. Please merge and release it.